### PR TITLE
Reverse Nodes in k-Group

### DIFF
--- a/Cpp/Linked List/Reverse Nodes in k-Groups.cpp
+++ b/Cpp/Linked List/Reverse Nodes in k-Groups.cpp
@@ -1,0 +1,40 @@
+/**
+ * Definition for singly-linked list.
+ * struct ListNode {
+ *     int val;
+ *     ListNode *next;
+ *     ListNode() : val(0), next(nullptr) {}
+ *     ListNode(int x) : val(x), next(nullptr) {}
+ *     ListNode(int x, ListNode *next) : val(x), next(next) {}
+ * };
+ */
+class Solution {
+public:
+    ListNode* reverseKGroup(ListNode* head, int k) {
+    
+        ListNode* cursor = head;
+        for(int i = 0; i < k; i++){
+            if(cursor == nullptr) return head;
+            cursor = cursor->next;
+        }
+    ListNode* curr=head;
+    ListNode* prev=NULL;
+    ListNode* forward=NULL;
+    int count=0;
+    while(curr!=NULL && count<k)
+    {
+        forward=curr->next;
+        curr->next=prev;
+        prev=curr;
+        curr=forward;
+        count++;
+        
+    }
+    if(forward!=NULL)
+    {  
+    head->next=reverseKGroup(forward,k);
+    }
+    
+    return prev;
+    }
+};

--- a/contributorlist
+++ b/contributorlist
@@ -25,6 +25,7 @@ SarinSthapit
 Omkar Jahagirdar
 
 Ayush Srivastava
+Harshit Kochhar
 
 
 


### PR DESCRIPTION
Given the head of a linked list, reverse the nodes of the list k at a time, and return the modified list.

k is a positive integer and is less than or equal to the length of the linked list. If the number of nodes is not a multiple of k then left-out nodes, in the end, should remain as it is.